### PR TITLE
Drilling Outpost Alignment 1.3 to 1.4

### DIFF
--- a/1.3/Source/VOE/Outpost_Drilling.cs
+++ b/1.3/Source/VOE/Outpost_Drilling.cs
@@ -12,7 +12,7 @@ namespace VOE
         [PostToSetings("Outposts.Settings.WorkToDrill", PostToSetingsAttribute.DrawMode.Time, 7 * GenDate.TicksPerDay, GenDate.TicksPerDay, GenDate.TicksPerYear)]
         public int WorkToDrill = 7 * 60000;
 
-        private bool Ready => workDone >= WorkToDrill;
+        private bool Ready => workDone >= WorkToDrill * 20;
 
         public override void PostMake()
         {
@@ -20,7 +20,7 @@ namespace VOE
             workDone = 0;
         }
 
-        public override IEnumerable<Thing> ProducedThings() => Ready ? new List<Thing>() : base.ProducedThings();
+        public override IEnumerable<Thing> ProducedThings() => Ready ? base.ProducedThings() : new List<Thing>();
 
         public override void Tick()
         {
@@ -30,8 +30,8 @@ namespace VOE
 
         public override string ProductionString() => Ready
             ? base.ProductionString()
-            : "Outposts.Drilling".Translate(((float) workDone / WorkToDrill).ToStringPercent(),
-                ((WorkToDrill - workDone) / TotalSkill(SkillDefOf.Construction)).ToStringTicksToPeriodVerbose().Colorize(ColoredText.DateTimeColor));
+            : "Outposts.Drilling".Translate(((float) workDone / (WorkToDrill * 20)).ToStringPercent(),
+                ((WorkToDrill * 20 - workDone) / TotalSkill(SkillDefOf.Construction)).ToStringTicksToPeriodVerbose().Colorize(ColoredText.DateTimeColor));
 
         public override void ExposeData()
         {


### PR DESCRIPTION
The bug itself seems to be fixed in v1.4, but not in v1.3. [BUG] Drilling Outpost produce resources when "Not Ready"/"Still drilling" and return empty list, when it done. So I adjusted code of class same way it was done in v1.4.

Also noticed that for v1.4 work to drill was multiplied by 20 to have week on skill lvl 20, but it also wasn't in v1.3. So I adjusted that part of code too to better align v1.3 to v1.4.

Didn't compile, cause was missing some dependencies for that, so overall it at least should help as a reference for a fix.